### PR TITLE
update environments for composer.sls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The states are independent of their actual location in the state file tree, so y
 
 ```yaml
 composer-github-token: xxxxx
-composer-home: '/opt/composer' # default - /root
+composer-home: '/opt/composer' # default - /root/.composer
+composer-allow-superuser: 0 # default - 1
 composer-plugins:  # name also used for match that plugin installed in composer global show
   - name: "composer-asset-plugin"
     src: "fxp/composer-asset-plugin:~1.4.4"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The states are independent of their actual location in the state file tree, so y
 
 ```yaml
 composer-github-token: xxxxx
-composer-home: '/opt/composer' # default - /root/.config/.composer
+composer-home: '/opt/composer' # default - /root/.config/composer
 composer-allow-superuser: 0 # default - 1
 composer-plugins:  # name also used for match that plugin installed in composer global show
   - name: "composer-asset-plugin"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The states are independent of their actual location in the state file tree, so y
 
 ```yaml
 composer-github-token: xxxxx
-composer-home: '/opt/composer' # default - /root/.composer
+composer-home: '/opt/composer' # default - /root/.config/.composer
 composer-allow-superuser: 0 # default - 1
 composer-plugins:  # name also used for match that plugin installed in composer global show
   - name: "composer-asset-plugin"

--- a/composer.sls
+++ b/composer.sls
@@ -11,7 +11,7 @@ composer_php:
         - unzip
         - git
 
-{% set composer_home =  pillar.get('composer-home', '/root/.config/.composer')%}
+{% set composer_home =  pillar.get('composer-home', '/root/.config/composer')%}
 
 # install composer
 composer_installed:

--- a/composer.sls
+++ b/composer.sls
@@ -11,12 +11,15 @@ composer_php:
         - unzip
         - git
 
+{% set composer_home =  pillar.get('composer-home', '/root/.config/.composer')%}
+
 # install composer
 composer_installed:
   cmd.run:
     - name: cd /usr/local/bin && curl -sS https://getcomposer.org/installer | php && ln -sf composer.phar composer
     - env:
-       - HOME: '{{pillar.get('composer-home', '/root')}}'
+       - COMPOSER_HOME: '{{composer_home}}'
+       - COMPOSER_ALLOW_SUPERUSER: {{ pillar.get('composer-allow-superuser', 1) }}
     - unless: test -x /usr/local/bin/composer
     - require:
         - pkg: composer_php
@@ -27,7 +30,8 @@ composer_{{plugin.name}}:
    cmd.run:
        - name: '/usr/local/bin/composer global require "{{plugin.src}}"'
        - env:
-          - HOME: '{{pillar.get('composer-home', '/root')}}'
+          - COMPOSER_HOME: '{{composer_home}}'
+          - COMPOSER_ALLOW_SUPERUSER: {{pillar.get('composer-allow-superuser', 1)}}
        - unless: /usr/local/bin/composer global show | grep {{plugin.name}}
        - require:
            - cmd: composer_installed
@@ -37,6 +41,9 @@ composer_{{plugin.name}}:
 composer_github_token:
   cmd.run:
     - name: composer config --global github-oauth.github.com {{ pillar['composer-github-token'] }}
+    - env:
+        - COMPOSER_HOME: '{{composer_home}}'
+        - COMPOSER_ALLOW_SUPERUSER: {{pillar.get('composer-allow-superuser', 1)}}
     - unless: test $(composer config --global github-oauth.github.com) = "{{ pillar['composer-github-token'] }}"
     - require:
         - cmd: composer_installed


### PR DESCRIPTION
- change env definiton HOME to COMPOSER_HOME, as more appropriate,  
   see https://getcomposer.org/installer source
- add env definition COMPOSER_ALLOW_SUPERUSER for mute warning
  (manageable from pillar)
- add missing env definitions for composer_github_token command